### PR TITLE
chore: add 'finish' type writer event

### DIFF
--- a/exercises/08-agents-and-workflows/08.03-creating-your-own-loop/solution/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.03-creating-your-own-loop/solution/api/chat.ts
@@ -137,6 +137,10 @@ export const POST = async (req: Request): Promise<Response> => {
         type: 'text-end',
         id: textPartId,
       });
+
+      writer.write({
+        type: 'finish',
+      });
     },
   });
 

--- a/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/problem/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/problem/api/chat.ts
@@ -139,6 +139,10 @@ export const POST = async (req: Request): Promise<Response> => {
         type: 'text-end',
         id: textPartId,
       });
+
+      writer.write({
+        type: 'finish',
+      });
     },
   });
 

--- a/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/solution/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/solution/api/chat.ts
@@ -163,6 +163,10 @@ export const POST = async (req: Request): Promise<Response> => {
         type: 'text-end',
         id: textPartId,
       });
+
+      writer.write({
+        type: 'finish',
+      });
     },
   });
 

--- a/exercises/99-reference/99.08-streaming-text-parts-by-hand/explainer/api/chat.ts
+++ b/exercises/99-reference/99.08-streaming-text-parts-by-hand/explainer/api/chat.ts
@@ -37,6 +37,10 @@ export const POST = async (req: Request): Promise<Response> => {
         type: 'text-end',
         id: textPartId,
       });
+
+      writer.write({
+        type: 'finish',
+      });
     },
   });
 


### PR DESCRIPTION
Some exercises with manual parts streaming were lacking 'finish' type events