### PR TITLE
Simplify chat creation logic in 04.03-persistence

### DIFF
--- a/exercises/04-persistence/04.03-persistence/solution/api/chat.ts
+++ b/exercises/04-persistence/04.03-persistence/solution/api/chat.ts
@@ -29,8 +29,7 @@ export const POST = async (req: Request): Promise<Response> => {
   }
 
   if (!chat) {
-    const newChat = await createChat(id, messages);
-    chat = newChat;
+    await createChat(id, messages);
   } else {
     await appendToChatMessages(id, [mostRecentMessage]);
   }


### PR DESCRIPTION
In this example, we’re no longer working with the `chat`, so assigning `newChat` to the chat constant is unnecessary.