### PR TITLE
chore: Use `DataTransfer` to send image files

### DIFF
--- a/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/problem/client/root.tsx
+++ b/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/problem/client/root.tsx
@@ -40,12 +40,9 @@ const App = () => {
           // _as well as the text_ to the
           // /api/chat route!
 
-          // NOTE: You have a helpful function below
-          // called fileToDataURL that you can use to
-          // convert the file to a data URL. This
-          // will be useful!
+          // NOTE: You can check `DataTransfer` class
           sendMessage({
-            // NOTE: 'parts' will be useful
+            // NOTE: 'files' will be useful
             text: input,
           });
 

--- a/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/solution/client/root.tsx
+++ b/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/solution/client/root.tsx
@@ -36,18 +36,12 @@ const App = () => {
           );
           const file = formData.get('file') as File;
 
+          const dataTransfer = new DataTransfer();
+          dataTransfer.items.add(file);
+
           sendMessage({
-            parts: [
-              {
-                type: 'text',
-                text: input,
-              },
-              {
-                type: 'file',
-                mediaType: file.type,
-                url: await fileToDataURL(file),
-              },
-            ],
+            text: input,
+            files: dataTransfer.files,
           });
           setInput('');
           setSelectedFile(null);
@@ -59,12 +53,3 @@ const App = () => {
 
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);
-
-const fileToDataURL = (file: File) => {
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
-};


### PR DESCRIPTION
In the 01.09 exercise about sending ima inage file along with the textual prompt, the solution proposes using a custom file to URL serialization, and using the `parts` API of the SDK.

This PR proposes a small change to use the [`DataTransfer`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer) Web API that I think is more affordable and direct to tackle the problem, avoiding the serialization stuff, and using directly the `files` prop of the `sendMessage``  function.

Anyway if using the `parts` API of `sendMessage` is a core pice of the exercise (I think it is nice to know about it), feel free to thiscard this PR.

Thank you!