### PR TITLE
03.05-mcp-via-sse - Replace deprecated SSE transport with Streamable HTTP transport

### DIFF
--- a/exercises/03-agents/03.04-mcp-via-stdio/problem/api/chat.ts
+++ b/exercises/03-agents/03.04-mcp-via-stdio/problem/api/chat.ts
@@ -5,8 +5,9 @@ import {
   streamText,
   type UIMessage,
 } from 'ai';
-import { experimental_createMCPClient as createMCPClient } from 'ai';
-import { Experimental_StdioMCPTransport as StdioMCPTransport } from 'ai/mcp-stdio';
+
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 
 if (!process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
   throw new Error('GITHUB_PERSONAL_ACCESS_TOKEN is not set');

--- a/exercises/03-agents/03.04-mcp-via-stdio/problem/readme.md
+++ b/exercises/03-agents/03.04-mcp-via-stdio/problem/readme.md
@@ -14,13 +14,13 @@ Luckily, the AI SDK has a few functions that help you do that.
 
 In this exercise, we'll be working in the [`POST`](./api/chat.ts) route only.
 
-We're first going to look at a couple of imported functions from [`ai`](./api/chat.ts) and `ai/mcp-stdio`. These are experimental, of course, because everything in MCP is experimental, and we're going to use them just below in our code.
+We're first going to look at a couple of imported functions from [`@ai-sdk/mcp`](./api/chat.ts) and `@ai-sdk/mcp/mcp-stdio`. These are experimental, of course, because everything in MCP is experimental, and we're going to use them just below in our code.
 
-Before we start streaming, we need to initiate an MCP client. This will use the [`StdioMCPTransport`](./api/chat.ts) from `ai/mcp-stdio`.
+Before we start streaming, we need to initiate an MCP client. This will use the [`StdioMCPTransport`](./api/chat.ts) from `@ai-sdk/mcp/mcp-stdio`.
 
 ```ts
-import { experimental_createMCPClient as createMCPClient } from 'ai';
-import { Experimental_StdioMCPTransport as StdioMCPTransport } from 'ai/mcp-stdio';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 ```
 
 What this is going to do is run a process locally and monitor its `stdin` and `stdout` in order to communicate with it.

--- a/exercises/03-agents/03.04-mcp-via-stdio/solution/api/chat.ts
+++ b/exercises/03-agents/03.04-mcp-via-stdio/solution/api/chat.ts
@@ -6,8 +6,8 @@ import {
   type UIMessage,
 } from 'ai';
 
-import { experimental_createMCPClient as createMCPClient } from 'ai';
-import { Experimental_StdioMCPTransport as StdioMCPTransport } from 'ai/mcp-stdio';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 
 if (!process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
   throw new Error('GITHUB_PERSONAL_ACCESS_TOKEN is not set');

--- a/exercises/03-agents/03.05-mcp-via-sse/explainer/api/chat.ts
+++ b/exercises/03-agents/03.05-mcp-via-sse/explainer/api/chat.ts
@@ -6,7 +6,7 @@ import {
   type UIMessage,
 } from 'ai';
 
-import { experimental_createMCPClient as createMCPClient } from 'ai';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 
 if (!process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
   throw new Error('GITHUB_PERSONAL_ACCESS_TOKEN is not set');
@@ -18,7 +18,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
   const mcpClient = await createMCPClient({
     transport: {
-      type: 'sse',
+      type: 'http',
       url: 'https://api.githubcopilot.com/mcp',
       headers: {
         Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,

--- a/exercises/03-agents/03.05-mcp-via-sse/explainer/readme.md
+++ b/exercises/03-agents/03.05-mcp-via-sse/explainer/readme.md
@@ -1,15 +1,13 @@
-I wanted to provide you an example of using SSE as a transport for an MCP client. In fact, this is my preferred way of teaching this because it means less setup for you.
+I wanted to provide you an example of using HTTP as a transport for an MCP client. In fact, this is my preferred way of teaching this because it means less setup for you.
 
-However, I simply could not get it working on my machine. So I've provided this example for you. Hopefully you can get it working, but I couldn't.
-
-The important difference is inside this [`createMCPClient`](./api/chat.ts) function, we no longer need to instantiate a `StdioMCPTransport`. We're now just passing in the information needed to contact the GitHub API via SSE.
+The important difference is inside this [`createMCPClient`](./api/chat.ts) function, we no longer need to instantiate a `StdioMCPTransport`. We're now just passing in the information needed to contact the GitHub API via HTTP.
 
 Let's look at the code:
 
 ```ts
 const mcpClient = await createMCPClient({
   transport: {
-    type: 'sse',
+    type: 'http',
     url: 'https://api.githubcopilot.com/mcp',
     headers: {
       Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
@@ -18,7 +16,7 @@ const mcpClient = await createMCPClient({
 });
 ```
 
-Instead of using the `StdioMCPTransport`, we're configuring an SSE (Server-Sent Events) transport that connects directly to GitHub's API.
+Instead of using the `StdioMCPTransport`, we're configuring an HTTP (Streamable HTTP) transport that connects directly to GitHub's API.
 
 I would suggest that you run this code, see if you can get it working. I think it was something to do with my strange WSL setup that was just making this balk. Good luck and I will see you in the next one.
 
@@ -26,8 +24,8 @@ I would suggest that you run this code, see if you can get it working. I think i
 
 - [ ] Make sure you have a GitHub [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) set in your environment variables
 
-- [ ] Try running the code as-is to see if the SSE transport works on your system
+- [ ] Try running the code as-is to see if the Streamable HTTP transport in action
 
 - [ ] Test the implementation by running your local dev server and seeing if GitHub API interactions work properly
 
-- [ ] Check for any error messages in your terminal that might indicate connection issues with the SSE transport
+- [ ] Check for any error messages in your terminal that might indicate connection issues with the Streamable HTTP transport

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@ai-sdk/anthropic": "^2.0.32",
     "@ai-sdk/google": "2.0.23",
     "@ai-sdk/openai": "^2.0.52",
+    "@ai-sdk/mcp": "^0.0.8",
     "@ai-sdk/react": "2.0.76",
     "@hono/node-server": "^1.15.0",
     "@opentelemetry/auto-instrumentations-node": "^0.62.0",
@@ -33,7 +34,7 @@
     "@types/prompts": "^2.4.9",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "ai": "5.0.76",
+    "ai": "5.0.92",
     "drizzle-orm": "^0.44.4",
     "evalite": "^0.15.0",
     "hono": "^4.8.4",
@@ -53,7 +54,7 @@
     "typescript": "^5.8.3",
     "vite": "^7.0.2",
     "vitest": "^3.2.4",
-    "zod": "^4.0.8"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/papaparse": "^5.3.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,19 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^2.0.32
-        version: 2.0.32(zod@4.0.8)
+        version: 2.0.32(zod@4.1.12)
       '@ai-sdk/google':
         specifier: 2.0.23
-        version: 2.0.23(zod@4.0.8)
+        version: 2.0.23(zod@4.1.12)
+      '@ai-sdk/mcp':
+        specifier: ^0.0.8
+        version: 0.0.8(zod@4.1.12)
       '@ai-sdk/openai':
         specifier: ^2.0.52
-        version: 2.0.52(zod@4.0.8)
+        version: 2.0.52(zod@4.1.12)
       '@ai-sdk/react':
         specifier: 2.0.76
-        version: 2.0.76(react@19.1.0)(zod@4.0.8)
+        version: 2.0.76(react@19.1.0)(zod@4.1.12)
       '@hono/node-server':
         specifier: ^1.15.0
         version: 1.15.0(hono@4.8.4)
@@ -57,8 +60,8 @@ importers:
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       ai:
-        specifier: 5.0.76
-        version: 5.0.76(zod@4.0.8)
+        specifier: 5.0.92
+        version: 5.0.92(zod@4.1.12)
       drizzle-orm:
         specifier: ^0.44.4
         version: 0.44.4(@cloudflare/workers-types@4.20250726.0)(@opentelemetry/api@1.9.0)(@types/pg@8.15.4)(better-sqlite3@11.10.0)(pg@8.11.3)(sqlite3@5.1.7)
@@ -76,7 +79,7 @@ importers:
         version: 3.38.4
       langfuse-vercel:
         specifier: ^3.38.4
-        version: 3.38.4(ai@5.0.76(zod@4.0.8))
+        version: 3.38.4(ai@5.0.92(zod@4.1.12))
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -117,8 +120,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)
       zod:
-        specifier: ^4.0.8
-        version: 4.0.8
+        specifier: ^4.1.8
+        version: 4.1.12
     devDependencies:
       '@types/papaparse':
         specifier: ^5.3.16
@@ -150,8 +153,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@2.0.8':
+    resolution: {integrity: sha512-cA5Sh5pjmsMOlzCxsX9B4bGB9qOn9/HRxKb8ry1OYmrXP3i1t34eZMHA7EVFoB09I41p0LPwkRBACYXm15xokw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google@2.0.23':
     resolution: {integrity: sha512-VbCnKR+6aWUVLkAiSW5gUEtST7KueEmlt+d6qwDikxlLnFG9pzy59je8MiDVeM5G2tuSXbvZQF78PGIfXDBmow==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@0.0.8':
+    resolution: {integrity: sha512-9y9GuGcZ9/+pMIHfpOCJgZVp+AZMv6TkjX2NVT17SQZvTF2N8LXuCXyoUPyi1PxIxzxl0n463LxxaB2O6olC+Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -164,6 +179,12 @@ packages:
 
   '@ai-sdk/provider-utils@3.0.12':
     resolution: {integrity: sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.17':
+    resolution: {integrity: sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1334,6 +1355,12 @@ packages:
 
   ai@5.0.76:
     resolution: {integrity: sha512-ZCxi1vrpyCUnDbtYrO/W8GLvyacV9689f00yshTIQ3mFFphbD7eIv40a2AOZBv3GGRA7SSRYIDnr56wcS/gyQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@5.0.92:
+    resolution: {integrity: sha512-EnPe3QXiD06Tg7iAt/oU3JSwedI1nuhEBnTjyfn1qTXaqmJ6qI4YG8wn/eBHRVXnmljDFDNYvGBC5pALYV1rAA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2536,6 +2563,10 @@ packages:
     resolution: {integrity: sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==}
     hasBin: true
 
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -3151,59 +3182,80 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  zod@4.0.8:
-    resolution: {integrity: sha512-+MSh9cZU9r3QKlHqrgHMTSr3QwMGv4PLfR0M4N/sYWV5/x67HgXEhIGObdBkpnX8G78pTgWnIrBL2lZcNJOtfg==}
+  zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
-  '@ai-sdk/anthropic@2.0.32(zod@4.0.8)':
+  '@ai-sdk/anthropic@2.0.32(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.0.8)
-      zod: 4.0.8
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
+      zod: 4.1.12
 
-  '@ai-sdk/gateway@2.0.0(zod@4.0.8)':
+  '@ai-sdk/gateway@2.0.0(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.0.8)
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
       '@vercel/oidc': 3.0.3
-      zod: 4.0.8
+      zod: 4.1.12
 
-  '@ai-sdk/google@2.0.23(zod@4.0.8)':
+  '@ai-sdk/gateway@2.0.8(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.0.8)
-      zod: 4.0.8
+      '@ai-sdk/provider-utils': 3.0.17(zod@4.1.12)
+      '@vercel/oidc': 3.0.3
+      zod: 4.1.12
 
-  '@ai-sdk/openai@2.0.52(zod@4.0.8)':
+  '@ai-sdk/google@2.0.23(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.0.8)
-      zod: 4.0.8
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
+      zod: 4.1.12
 
-  '@ai-sdk/provider-utils@3.0.12(zod@4.0.8)':
+  '@ai-sdk/mcp@0.0.8(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.17(zod@4.1.12)
+      pkce-challenge: 5.0.0
+      zod: 4.1.12
+
+  '@ai-sdk/openai@2.0.52(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
+      zod: 4.1.12
+
+  '@ai-sdk/provider-utils@3.0.12(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
-      zod: 4.0.8
+      zod: 4.1.12
+
+  '@ai-sdk/provider-utils@3.0.17(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.12
 
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@2.0.76(react@19.1.0)(zod@4.0.8)':
+  '@ai-sdk/react@2.0.76(react@19.1.0)(zod@4.1.12)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.0.8)
-      ai: 5.0.76(zod@4.0.8)
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
+      ai: 5.0.76(zod@4.1.12)
       react: 19.1.0
       swr: 2.3.6(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 4.0.8
+      zod: 4.1.12
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -4478,13 +4530,21 @@ snapshots:
 
   ai-hero-cli@0.1.1: {}
 
-  ai@5.0.76(zod@4.0.8):
+  ai@5.0.76(zod@4.1.12):
     dependencies:
-      '@ai-sdk/gateway': 2.0.0(zod@4.0.8)
+      '@ai-sdk/gateway': 2.0.0(zod@4.1.12)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.12(zod@4.0.8)
+      '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
       '@opentelemetry/api': 1.9.0
-      zod: 4.0.8
+      zod: 4.1.12
+
+  ai@5.0.92(zod@4.1.12):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.8(zod@4.1.12)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.17(zod@4.1.12)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.12
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -5215,9 +5275,9 @@ snapshots:
     dependencies:
       mustache: 4.2.0
 
-  langfuse-vercel@3.38.4(ai@5.0.76(zod@4.0.8)):
+  langfuse-vercel@3.38.4(ai@5.0.92(zod@4.1.12)):
     dependencies:
-      ai: 5.0.76(zod@4.0.8)
+      ai: 5.0.92(zod@4.1.12)
       langfuse: 3.38.4
       langfuse-core: 3.38.4
 
@@ -5803,6 +5863,8 @@ snapshots:
       slow-redact: 0.3.2
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
+
+  pkce-challenge@5.0.0: {}
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -6492,6 +6554,6 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  zod@4.0.8: {}
+  zod@4.1.12: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
This pull request aims to solve the exercise `03.05-mcp-via-sse`.

The SSE transport has been deprecated in favor of [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http).
Vercel recently updated the [MCP documentation page](https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools) and released a new package, `@ai-sdk/mcp`.
In this new version, they support the new HTTP transport, so the exercise can now be solved by using `createMCPClient` from this new package and setting the `type` to `http` instead of `sse`.

### Update dependencies

- I added the new dependency `"@ai-sdk/mcp": "^0.0.8"`.
- I updated `ai` from `5.0.76` to `5.0.92`.
- I updated `zod` from `4.0.8` to `4.1.8` (all `@ai-sdk/*` deps require `zod: ^3.25.76 || ^4.1.8` as peerDep).

### Code changes

- I migrated MCP client imports in `api/chat.ts` files from `ai` and `ai/mcp-stdio` to `@ai-sdk/mcp` and `@ai-sdk/mcp/mcp-stdio` for both the problem and solution implementations.
  
  ```diff
  -import { experimental_createMCPClient as createMCPClient } from 'ai';
  +import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
  
  -import { Experimental_StdioMCPTransport as StdioMCPTransport } from 'ai/mcp-stdio';
  +import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
  ```

- I changed the MCP transport type from `'sse'` to `'http'` to use streamable HTTP transport instead of SSE.
  
  ```diff
    const mcpClient = await createMCPClient({
      transport: {
  -     type: 'sse',
  +     type: 'http',
        url: 'https://api.githubcopilot.com/mcp',
        headers: {
          Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
        },
      },
    });
  ```

### Documentation changes

- I updated documentation in two `readme.md` files to reflect the switch from SSE to HTTP transport.

### Other considerations

- Probably we should rename the folder `03.05-mcp-via-sse` to `03.05-mcp-via-http`.
- You may probably need to update/adjust the wording of the two `readme.md` I changed.
