### PR TITLE
Replace model references to gemini-2.0-flash* in favor of gemini-2.5-…

### DIFF
--- a/exercises/01-ai-sdk-basics/01.04-generating-text/problem/main.ts
+++ b/exercises/01-ai-sdk-basics/01.04-generating-text/problem/main.ts
@@ -2,7 +2,7 @@ import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
 // TODO: Choose a model. I recommend using the Google Gemini model:
-// gemini-2.0-flash-lite
+// gemini-2.5-flash-lite
 const model = TODO;
 
 const prompt = 'What is the capital of France?';

--- a/exercises/01-ai-sdk-basics/01.04-generating-text/problem/readme.md
+++ b/exercises/01-ai-sdk-basics/01.04-generating-text/problem/readme.md
@@ -11,7 +11,7 @@ import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
 // TODO: Choose a model. I recommend using the Google Gemini model:
-// gemini-2.0-flash
+// gemini-2.5-flash
 const model = TODO;
 ```
 

--- a/exercises/01-ai-sdk-basics/01.04-generating-text/solution/main.ts
+++ b/exercises/01-ai-sdk-basics/01.04-generating-text/solution/main.ts
@@ -1,7 +1,7 @@
 import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
-const model = google('gemini-2.0-flash-lite');
+const model = google('gemini-2.5-flash-lite');
 
 const prompt = 'What is the capital of France?';
 

--- a/exercises/01-ai-sdk-basics/01.05-stream-text-to-terminal/problem/main.ts
+++ b/exercises/01-ai-sdk-basics/01.05-stream-text-to-terminal/problem/main.ts
@@ -1,7 +1,7 @@
 import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
-const model = google('gemini-2.0-flash');
+const model = google('gemini-2.5-flash');
 
 const prompt =
   'Give me the first paragraph of a story about an imaginary planet.';

--- a/exercises/01-ai-sdk-basics/01.05-stream-text-to-terminal/problem/readme.md
+++ b/exercises/01-ai-sdk-basics/01.05-stream-text-to-terminal/problem/readme.md
@@ -8,7 +8,7 @@ Let's look at the problem we need to solve:
 import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
-const model = google('gemini-2.0-flash');
+const model = google('gemini-2.5-flash');
 
 const prompt =
   'Give me the first paragraph of a story about an imaginary planet.';

--- a/exercises/01-ai-sdk-basics/01.05-stream-text-to-terminal/solution/main.ts
+++ b/exercises/01-ai-sdk-basics/01.05-stream-text-to-terminal/solution/main.ts
@@ -1,7 +1,7 @@
 import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
-const model = google('gemini-2.0-flash');
+const model = google('gemini-2.5-flash');
 
 const stream = streamText({
   model,

--- a/exercises/01-ai-sdk-basics/01.06-ui-message-streams/explainer/main.ts
+++ b/exercises/01-ai-sdk-basics/01.06-ui-message-streams/explainer/main.ts
@@ -1,7 +1,7 @@
 import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
-const model = google('gemini-2.0-flash');
+const model = google('gemini-2.5-flash');
 
 const stream = streamText({
   model,

--- a/exercises/01-ai-sdk-basics/01.07-stream-text-to-ui/problem/api/chat.ts
+++ b/exercises/01-ai-sdk-basics/01.07-stream-text-to-ui/problem/api/chat.ts
@@ -17,7 +17,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
   // TODO: pass the modelMessages to streamText
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
   });
 
   // TODO: create a UIMessageStream from the streamTextResult

--- a/exercises/01-ai-sdk-basics/01.07-stream-text-to-ui/problem/readme.md
+++ b/exercises/01-ai-sdk-basics/01.07-stream-text-to-ui/problem/readme.md
@@ -53,7 +53,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
   // TODO: pass the modelMessages to streamText
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
   });
 
   // TODO: create a UIMessageStream from the streamTextResult

--- a/exercises/01-ai-sdk-basics/01.07-stream-text-to-ui/solution/api/chat.ts
+++ b/exercises/01-ai-sdk-basics/01.07-stream-text-to-ui/solution/api/chat.ts
@@ -16,7 +16,7 @@ export const POST = async (req: Request): Promise<Response> => {
     convertToModelMessages(messages);
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
   });
 

--- a/exercises/01-ai-sdk-basics/01.08-system-prompts/explainer/api/chat.ts
+++ b/exercises/01-ai-sdk-basics/01.08-system-prompts/explainer/api/chat.ts
@@ -24,7 +24,7 @@ export const POST = async (req: Request): Promise<Response> => {
     convertToModelMessages(messages);
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
     system: SYSTEM_PROMPT,
   });

--- a/exercises/01-ai-sdk-basics/01.08-system-prompts/explainer/readme.md
+++ b/exercises/01-ai-sdk-basics/01.08-system-prompts/explainer/readme.md
@@ -18,7 +18,7 @@ We're then passing the system prompt into [`streamText`](./api/chat.ts) here und
 
 ```ts
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   messages: modelMessages,
   system: SYSTEM_PROMPT,
 });

--- a/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/problem/api/chat.ts
+++ b/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/problem/api/chat.ts
@@ -16,7 +16,7 @@ export const POST = async (req: Request): Promise<Response> => {
     convertToModelMessages(messages);
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
   });
 

--- a/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/problem/readme.md
+++ b/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/problem/readme.md
@@ -18,7 +18,7 @@ export const POST = async (req: Request): Promise<Response> => {
     convertToModelMessages(messages);
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
   });
 
@@ -30,7 +30,7 @@ export const POST = async (req: Request): Promise<Response> => {
 };
 ```
 
-We're calling Gemini 2.0 Flash, which is a model that can handle images. Not all models can handle images, so check your provider details for more info.
+We're calling Gemini 2.5 Flash, which is a model that can handle images. Not all models can handle images, so check your provider details for more info.
 
 We're converting the messages that we get from the body into `ModelMessage`s, passing those messages directly into `streamText`, then turning that into a `UIMessageStream`, which we stream back to the frontend.
 

--- a/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/solution/api/chat.ts
+++ b/exercises/01-ai-sdk-basics/01.09-passing-images-and-files/solution/api/chat.ts
@@ -16,7 +16,7 @@ export const POST = async (req: Request): Promise<Response> => {
     convertToModelMessages(messages);
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
   });
 

--- a/exercises/01-ai-sdk-basics/01.10-streaming-objects/problem/main.ts
+++ b/exercises/01-ai-sdk-basics/01.10-streaming-objects/problem/main.ts
@@ -1,7 +1,7 @@
 import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
-const model = google('gemini-2.0-flash');
+const model = google('gemini-2.5-flash');
 
 const stream = streamText({
   model,

--- a/exercises/01-ai-sdk-basics/01.10-streaming-objects/problem/readme.md
+++ b/exercises/01-ai-sdk-basics/01.10-streaming-objects/problem/readme.md
@@ -28,7 +28,7 @@ const finalText = await stream.text;
 
 Our first to-do is to call `streamObject` from the AI SDK, passing in:
 
-1. The model (Gemini 2.0 Flash)
+1. The model (Gemini 2.5 Flash)
 2. A prompt asking for facts about the imaginary planet
 3. A Zod schema defining the structure we want back
 

--- a/exercises/01-ai-sdk-basics/01.10-streaming-objects/solution/main.ts
+++ b/exercises/01-ai-sdk-basics/01.10-streaming-objects/solution/main.ts
@@ -2,7 +2,7 @@ import { google } from '@ai-sdk/google';
 import { streamObject, streamText } from 'ai';
 import z from 'zod';
 
-const model = google('gemini-2.0-flash');
+const model = google('gemini-2.5-flash');
 
 const stream = streamText({
   model,

--- a/exercises/02-llm-fundamentals/02.02-usage/problem/main.ts
+++ b/exercises/02-llm-fundamentals/02.02-usage/problem/main.ts
@@ -2,7 +2,7 @@ import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
 const output = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `Which country makes the best sausages? Answer in a single paragraph.`,
 });
 

--- a/exercises/02-llm-fundamentals/02.02-usage/problem/readme.md
+++ b/exercises/02-llm-fundamentals/02.02-usage/problem/readme.md
@@ -11,7 +11,7 @@ import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
 const output = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `Which country makes the best sausages? Answer in a single paragraph.`,
 });
 

--- a/exercises/02-llm-fundamentals/02.02-usage/solution/main.ts
+++ b/exercises/02-llm-fundamentals/02.02-usage/solution/main.ts
@@ -2,7 +2,7 @@ import { google } from '@ai-sdk/google';
 import { streamText } from 'ai';
 
 const output = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `Which country makes the best sausages? Answer in a single paragraph.`,
 });
 

--- a/exercises/02-llm-fundamentals/02.04-context-window/explainer/main.ts
+++ b/exercises/02-llm-fundamentals/02.04-context-window/explainer/main.ts
@@ -25,7 +25,7 @@ const tokens = tokenize(text);
 console.log(`Tokens length: ${tokens.length}`);
 
 await generateText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: text,
   // NOTE: by default, the AI SDK retries the request 3 times
   // if it fails. We can prevent this by setting maxRetries to 0.

--- a/exercises/02-llm-fundamentals/02.04-context-window/explainer/readme.md
+++ b/exercises/02-llm-fundamentals/02.04-context-window/explainer/readme.md
@@ -43,7 +43,7 @@ However, we're expecting it to fail, so we're going to set it to zero:
 
 ```typescript
 await generateText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: text,
   maxRetries: 0,
 });

--- a/exercises/04-persistence/04.01-on-finish/explainer/api/chat.ts
+++ b/exercises/04-persistence/04.01-on-finish/explainer/api/chat.ts
@@ -10,7 +10,7 @@ export const POST = async (req: Request): Promise<Response> => {
   const { messages } = body;
 
   const result = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
     onFinish: ({ response }) => {
       // 'response.messages' is an array of ToolModelMessage and AssistantModelMessage,

--- a/exercises/04-persistence/04.01-on-finish/explainer/readme.md
+++ b/exercises/04-persistence/04.01-on-finish/explainer/readme.md
@@ -10,7 +10,7 @@ export const POST = async (req: Request): Promise<Response> => {
   const { messages } = body;
 
   const result = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
     onFinish: ({ response }) => {
       console.log('streamText.onFinish');

--- a/exercises/04-persistence/04.02-pass-chat-id-to-the-api/problem/api/chat.ts
+++ b/exercises/04-persistence/04.02-pass-chat-id-to-the-api/problem/api/chat.ts
@@ -13,7 +13,7 @@ export const POST = async (req: Request): Promise<Response> => {
   console.log('id', id);
 
   const result = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
   });
 

--- a/exercises/04-persistence/04.02-pass-chat-id-to-the-api/solution/api/chat.ts
+++ b/exercises/04-persistence/04.02-pass-chat-id-to-the-api/solution/api/chat.ts
@@ -13,7 +13,7 @@ export const POST = async (req: Request): Promise<Response> => {
   console.log('id', id);
 
   const result = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
   });
 

--- a/exercises/04-persistence/04.03-persistence/problem/api/chat.ts
+++ b/exercises/04-persistence/04.03-persistence/problem/api/chat.ts
@@ -38,7 +38,7 @@ export const POST = async (req: Request): Promise<Response> => {
   // TODO: wait for the stream to finish and append the
   // last message to the chat
   const result = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
   });
 

--- a/exercises/04-persistence/04.03-persistence/problem/readme.md
+++ b/exercises/04-persistence/04.03-persistence/problem/readme.md
@@ -126,7 +126,7 @@ export const POST = async (req: Request): Promise<Response> => {
   // TODO: wait for the stream to finish and append the
   // last message to the chat
   const result = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
   });
 

--- a/exercises/04-persistence/04.03-persistence/solution/api/chat.ts
+++ b/exercises/04-persistence/04.03-persistence/solution/api/chat.ts
@@ -36,7 +36,7 @@ export const POST = async (req: Request): Promise<Response> => {
   }
 
   const result = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     messages: convertToModelMessages(messages),
   });
 

--- a/exercises/04-persistence/04.05-validating-messages/explainer/api/chat.ts
+++ b/exercises/04-persistence/04.05-validating-messages/explainer/api/chat.ts
@@ -25,7 +25,7 @@ export const POST = async (req: Request): Promise<Response> => {
     convertToModelMessages(messages);
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
   });
 

--- a/exercises/05-context-engineering/05.02-basic-prompting/problem/main.ts
+++ b/exercises/05-context-engineering/05.02-basic-prompting/problem/main.ts
@@ -6,7 +6,7 @@ const INPUT = `Do some research on induction hobs and how I can replace a 100cm 
 // NOTE: A good output would be: "Induction hobs vs AGA cookers"
 
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   // TODO: Rewrite this prompt using the Anthropic template from
   // the previous exercise.
   // You will NOT need all of the sections from the template.

--- a/exercises/05-context-engineering/05.02-basic-prompting/problem/readme.md
+++ b/exercises/05-context-engineering/05.02-basic-prompting/problem/readme.md
@@ -6,7 +6,7 @@ Looking at our current code:
 
 ```typescript
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   // TODO: Rewrite this prompt using the Anthropic template from
   // the previous exercise.
   // You will NOT need all of the sections from the template.

--- a/exercises/05-context-engineering/05.02-basic-prompting/solution/main.ts
+++ b/exercises/05-context-engineering/05.02-basic-prompting/solution/main.ts
@@ -4,7 +4,7 @@ import { streamText } from 'ai';
 const INPUT = `Do some research on induction hobs and how I can replace a 100cm wide AGA cooker with an induction range cooker. Which is the cheapest, which is the best?`;
 
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful assistant that can generate titles for conversations.

--- a/exercises/05-context-engineering/05.03-exemplars/problem/main.ts
+++ b/exercises/05-context-engineering/05.03-exemplars/problem/main.ts
@@ -15,7 +15,7 @@ const exemplars = [
 ];
 
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful assistant that can generate titles for conversations.

--- a/exercises/05-context-engineering/05.03-exemplars/problem/readme.md
+++ b/exercises/05-context-engineering/05.03-exemplars/problem/readme.md
@@ -17,7 +17,7 @@ const exemplars = [
 ];
 
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful assistant that can generate titles for conversations.

--- a/exercises/05-context-engineering/05.03-exemplars/solution/main.ts
+++ b/exercises/05-context-engineering/05.03-exemplars/solution/main.ts
@@ -15,7 +15,7 @@ const exemplars = [
 ];
 
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <examples>
       ${exemplars

--- a/exercises/05-context-engineering/05.04-retrieval/problem/main.ts
+++ b/exercises/05-context-engineering/05.04-retrieval/problem/main.ts
@@ -40,7 +40,7 @@ if (!rawContent) {
 // TODO: Add some rules telling the model to use paragraphs in its output, and to use quotes from the content of the website to answer the question.
 // TODO: Add the output format telling the model to return only the summary, not any other text.
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful assistant that summarizes the content of a URL.

--- a/exercises/05-context-engineering/05.04-retrieval/problem/readme.md
+++ b/exercises/05-context-engineering/05.04-retrieval/problem/readme.md
@@ -65,7 +65,7 @@ Now, we need to complete three TODO items in the prompt template:
 // TODO: Add some rules telling the model to use paragraphs in its output, and to use quotes from the content of the website to answer the question.
 // TODO: Add the output format telling the model to return only the summary, not any other text.
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful assistant that summarizes the content of a URL.

--- a/exercises/05-context-engineering/05.04-retrieval/solution/main.ts
+++ b/exercises/05-context-engineering/05.04-retrieval/solution/main.ts
@@ -37,7 +37,7 @@ if (!rawContent) {
 }
 
 const result = await streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful assistant that summarizes the content of a URL.

--- a/exercises/05-context-engineering/05.05-chain-of-thought/problem/main.ts
+++ b/exercises/05-context-engineering/05.05-chain-of-thought/problem/main.ts
@@ -16,7 +16,7 @@ const IIMT_ARTICLE = readFileSync(
 // TODO: Add some instructions telling the model to think about its answer first before it responds. Consider the optimal path for the user to understand the code, including each individual piece of syntax.
 // TODO: Add an output format telling the model to return two sections - a <thinking> block and an answer. The answer should NOT be wrapped in an <answer> tag.
 const result = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful TypeScript expert that can explain complex TypeScript code for beginner TypeScript developers. You will be given a complex TypeScript code and you will need to explain it in a way that is easy to understand.

--- a/exercises/05-context-engineering/05.05-chain-of-thought/problem/readme.md
+++ b/exercises/05-context-engineering/05.05-chain-of-thought/problem/readme.md
@@ -15,7 +15,7 @@ We've provided it some detailed task context here:
 
 ```typescript
 const result = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful TypeScript expert that can explain complex TypeScript code for beginner TypeScript developers. You will be given a complex TypeScript code and you will need to explain it in a way that is easy to understand.

--- a/exercises/05-context-engineering/05.05-chain-of-thought/solution/main.ts
+++ b/exercises/05-context-engineering/05.05-chain-of-thought/solution/main.ts
@@ -14,7 +14,7 @@ const IIMT_ARTICLE = readFileSync(
 );
 
 const result = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     <task-context>
     You are a helpful TypeScript expert that can explain complex TypeScript code for beginner TypeScript developers. You will be given a complex TypeScript code and you will need to explain it in a way that is easy to understand.

--- a/exercises/06-evals/06.01-evalite-basics/solution/evals/example.eval.ts
+++ b/exercises/06-evals/06.01-evalite-basics/solution/evals/example.eval.ts
@@ -19,7 +19,7 @@ evalite('Capitals', {
   ],
   task: async (input) => {
     const capitalResult = await generateText({
-      model: google('gemini-2.0-flash-lite'),
+      model: google('gemini-2.5-flash-lite'),
       prompt: `
         You are a helpful assistant that can answer questions about the capital of countries.
 

--- a/exercises/06-evals/06.02-deterministic-eval/problem/evals/question-answerer.eval.ts
+++ b/exercises/06-evals/06.02-deterministic-eval/problem/evals/question-answerer.eval.ts
@@ -52,7 +52,7 @@ evalite('TS Release Notes', {
   ],
   task: async (input) => {
     const capitalResult = await generateText({
-      model: google('gemini-2.0-flash-lite'),
+      model: google('gemini-2.5-flash-lite'),
       prompt: `
         You are a helpful assistant that can answer questions about TypeScript releases.
 

--- a/exercises/06-evals/06.02-deterministic-eval/solution/evals/question-answerer.eval.ts
+++ b/exercises/06-evals/06.02-deterministic-eval/solution/evals/question-answerer.eval.ts
@@ -52,7 +52,7 @@ evalite('TS Release Notes', {
   ],
   task: async (input) => {
     const capitalResult = await generateText({
-      model: google('gemini-2.0-flash-lite'),
+      model: google('gemini-2.5-flash-lite'),
       prompt: `
         You are a helpful assistant that can answer questions about TypeScript releases.
 

--- a/exercises/06-evals/06.03-llm-as-a-judge-eval/problem/evals/attribution-eval.ts
+++ b/exercises/06-evals/06.03-llm-as-a-judge-eval/problem/evals/attribution-eval.ts
@@ -32,7 +32,7 @@ export const attributionToChainOfThoughtPaper = createScorer<
   name: 'Attribution',
   scorer: async ({ input, output }) => {
     const result = await generateObject({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       system: ATTRIBUTION_PROMPT,
       messages: TODO, // TODO: Pass the chain of thought paper, the question and the answer given
       schema: TODO, // TODO: Define the schema for the response

--- a/exercises/06-evals/06.03-llm-as-a-judge-eval/problem/evals/question-answerer.eval.ts
+++ b/exercises/06-evals/06.03-llm-as-a-judge-eval/problem/evals/question-answerer.eval.ts
@@ -24,7 +24,7 @@ evalite('Chain Of Thought Paper', {
   ],
   task: async (input) => {
     const result = await generateText({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       system: `
         You are a helpful assistant that can answer questions about the chain of thought prompting paper.
       `,

--- a/exercises/06-evals/06.03-llm-as-a-judge-eval/problem/readme.md
+++ b/exercises/06-evals/06.03-llm-as-a-judge-eval/problem/readme.md
@@ -32,7 +32,7 @@ evalite('Chain Of Thought Paper', {
   ],
   task: async (input) => {
     const result = await generateText({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       system: `
         You are a helpful assistant that can answer questions about the chain of thought prompting paper.
 
@@ -97,7 +97,7 @@ export const attributionToChainOfThoughtPaper = createScorer<
   name: 'Attribution',
   scorer: async ({ input, output, expected }) => {
     const result = await generateObject({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       system: ATTRIBUTION_PROMPT,
       messages: TODO, // TODO: Pass the chain of thought paper, the question and the answer given
       schema: TODO, // TODO: Define the schema for the response

--- a/exercises/06-evals/06.03-llm-as-a-judge-eval/solution/evals/attribution-eval.ts
+++ b/exercises/06-evals/06.03-llm-as-a-judge-eval/solution/evals/attribution-eval.ts
@@ -19,7 +19,7 @@ export const attributionToChainOfThoughtPaper = createScorer<
   name: 'Attribution',
   scorer: async ({ input, output, expected }) => {
     const result = await generateObject({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       system: `
         You are a helpful assistant that can answer questions about the chain of thought prompting paper.
 

--- a/exercises/06-evals/06.03-llm-as-a-judge-eval/solution/evals/question-answerer.eval.ts
+++ b/exercises/06-evals/06.03-llm-as-a-judge-eval/solution/evals/question-answerer.eval.ts
@@ -25,7 +25,7 @@ evalite('Chain Of Thought Paper', {
   ],
   task: async (input) => {
     const result = await generateText({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       system: `
         You are a helpful assistant that can answer questions about the chain of thought prompting paper.
         

--- a/exercises/06-evals/06.05-chat-title-generation/problem/evals/chat-title-generation.eval.ts
+++ b/exercises/06-evals/06.05-chat-title-generation/problem/evals/chat-title-generation.eval.ts
@@ -31,7 +31,7 @@ evalite('Chat Title Generation', {
   data: () => dataForEvalite,
   task: async (input) => {
     const result = await generateText({
-      model: google('gemini-2.0-flash-lite'),
+      model: google('gemini-2.5-flash-lite'),
       prompt: `
         Generate me a title:
         ${input}

--- a/exercises/06-evals/06.05-chat-title-generation/problem/readme.md
+++ b/exercises/06-evals/06.05-chat-title-generation/problem/readme.md
@@ -2,11 +2,11 @@ Now we understand the basics about evals and how you can use LLM as a judge, sco
 
 ## The Eval
 
-We have an eval here called chat title generation that simply calls `generateText` passing in `google('gemini-2.0-flash-lite')` and says "generate me a title based on an input.":
+We have an eval here called chat title generation that simply calls `generateText` passing in `google('gemini-2.5-flash-lite')` and says "generate me a title based on an input.":
 
 ```typescript
 const result = await generateText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     Generate me a title:
     ${input}
@@ -52,7 +52,7 @@ Here's how I recommend you complete this exercise:
 
 ```typescript
 const result = await generateText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   prompt: `
     Generate me a title:
     ${input}

--- a/exercises/06-evals/06.05-chat-title-generation/solution/evals/chat-title-generation.eval.ts
+++ b/exercises/06-evals/06.05-chat-title-generation/solution/evals/chat-title-generation.eval.ts
@@ -31,7 +31,7 @@ evalite('Chat Title Generation', {
   data: () => dataForEvalite,
   task: async (input) => {
     const result = await generateText({
-      model: google('gemini-2.0-flash-lite'),
+      model: google('gemini-2.5-flash-lite'),
       prompt: `
         You are a helpful assistant that can generate titles for conversations. The title will be used for organizing conversations in a chat application.
 

--- a/exercises/06-evals/06.07-langfuse-basics/problem/api/chat.ts
+++ b/exercises/06-evals/06.07-langfuse-basics/problem/api/chat.ts
@@ -38,7 +38,7 @@ export const POST = async (req: Request): Promise<Response> => {
     .join('');
 
   const titleResult = generateText({
-    model: google('gemini-2.0-flash-lite'),
+    model: google('gemini-2.5-flash-lite'),
     prompt: `
       You are a helpful assistant that can generate titles for conversations.
 
@@ -66,7 +66,7 @@ export const POST = async (req: Request): Promise<Response> => {
   });
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
     // TODO: declare the experimental_telemetry property using the following object:
     // - isEnabled: true

--- a/exercises/06-evals/06.07-langfuse-basics/solution/api/chat.ts
+++ b/exercises/06-evals/06.07-langfuse-basics/solution/api/chat.ts
@@ -37,7 +37,7 @@ export const POST = async (req: Request): Promise<Response> => {
     .join('');
 
   const titleResult = generateText({
-    model: google('gemini-2.0-flash-lite'),
+    model: google('gemini-2.5-flash-lite'),
     prompt: `
       You are a helpful assistant that can generate titles for conversations.
 
@@ -67,7 +67,7 @@ export const POST = async (req: Request): Promise<Response> => {
   });
 
   const streamTextResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     messages: modelMessages,
     experimental_telemetry: {
       isEnabled: true,

--- a/exercises/07-streaming/07.01-custom-data-parts/problem/api/chat.ts
+++ b/exercises/07-streaming/07.01-custom-data-parts/problem/api/chat.ts
@@ -27,7 +27,7 @@ export const POST = async (req: Request): Promise<Response> => {
   const stream = createUIMessageStream<MyMessage>({
     execute: async ({ writer }) => {
       const streamTextResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 
@@ -36,7 +36,7 @@ export const POST = async (req: Request): Promise<Response> => {
       await streamTextResult.consumeStream();
 
       const followupSuggestionsResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: [
           ...modelMessages,
           {

--- a/exercises/07-streaming/07.01-custom-data-parts/problem/readme.md
+++ b/exercises/07-streaming/07.01-custom-data-parts/problem/readme.md
@@ -45,7 +45,7 @@ The `writer` variable, a `UIMessageStreamWriter`, has two really important metho
 const stream = createUIMessageStream<MyMessage>({
   execute: async ({ writer }) => {
     const streamTextResult = streamText({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       messages: modelMessages,
     });
 
@@ -66,7 +66,7 @@ After consuming the first stream, we call `streamText` again to get a follow-up 
 
 ```ts
 const followupSuggestionsResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   messages: [
     ...modelMessages,
     {

--- a/exercises/07-streaming/07.01-custom-data-parts/solution/api/chat.ts
+++ b/exercises/07-streaming/07.01-custom-data-parts/solution/api/chat.ts
@@ -26,7 +26,7 @@ export const POST = async (req: Request): Promise<Response> => {
   const stream = createUIMessageStream<MyMessage>({
     execute: async ({ writer }) => {
       const streamTextResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 
@@ -35,7 +35,7 @@ export const POST = async (req: Request): Promise<Response> => {
       await streamTextResult.consumeStream();
 
       const followupSuggestionsResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: [
           ...modelMessages,
           {

--- a/exercises/07-streaming/07.02-custom-data-parts-with-stream-object/problem/api/chat.ts
+++ b/exercises/07-streaming/07.02-custom-data-parts-with-stream-object/problem/api/chat.ts
@@ -28,7 +28,7 @@ export const POST = async (req: Request): Promise<Response> => {
   const stream = createUIMessageStream<MyMessage>({
     execute: async ({ writer }) => {
       const streamTextResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 
@@ -40,7 +40,7 @@ export const POST = async (req: Request): Promise<Response> => {
       // since we'll need to use structured outputs to reliably
       // generate multiple suggestions
       const followupSuggestionsResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         // TODO: Define the schema for the suggestions
         // using zod
         schema: TODO,

--- a/exercises/07-streaming/07.02-custom-data-parts-with-stream-object/problem/readme.md
+++ b/exercises/07-streaming/07.02-custom-data-parts-with-stream-object/problem/readme.md
@@ -30,7 +30,7 @@ We also need to define a schema using Zod to ensure we get the correct data stru
 // since we'll need to use structured outputs to reliably
 // generate multiple suggestions
 const followupSuggestionsResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   // TODO: Define the schema for the suggestions
   // using zod
   schema: TODO,

--- a/exercises/07-streaming/07.02-custom-data-parts-with-stream-object/solution/api/chat.ts
+++ b/exercises/07-streaming/07.02-custom-data-parts-with-stream-object/solution/api/chat.ts
@@ -28,7 +28,7 @@ export const POST = async (req: Request): Promise<Response> => {
   const stream = createUIMessageStream<MyMessage>({
     execute: async ({ writer }) => {
       const streamTextResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 
@@ -37,7 +37,7 @@ export const POST = async (req: Request): Promise<Response> => {
       await streamTextResult.consumeStream();
 
       const followupSuggestionsResult = streamObject({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         schema: z.object({
           suggestions: z.array(z.string()),
         }),

--- a/exercises/08-agents-and-workflows/08.01-workflow/solution/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.01-workflow/solution/api/chat.ts
@@ -35,7 +35,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
   // Write Slack message
   const writeSlackResult = await generateText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
     prompt: `
       Conversation history:
@@ -45,7 +45,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
   // Evaluate Slack message
   const evaluateSlackResult = await generateText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     system: EVALUATE_SLACK_MESSAGE_SYSTEM,
     prompt: `
       Conversation history:
@@ -58,7 +58,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
   // Write final Slack message
   const finalSlackAttempt = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     system: WRITE_SLACK_MESSAGE_FINAL_SYSTEM,
     prompt: `
       Conversation history:

--- a/exercises/08-agents-and-workflows/08.02-streaming-custom-data-to-the-frontend/problem/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.02-streaming-custom-data-to-the-frontend/problem/api/chat.ts
@@ -55,7 +55,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // TODO - change to streamText and write to the stream as custom data parts
       const writeSlackResult = await generateText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
         prompt: `
           Conversation history:
@@ -65,7 +65,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // TODO - change to streamText and write to the stream as custom data parts
       const evaluateSlackResult = await generateText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: EVALUATE_SLACK_MESSAGE_SYSTEM,
         prompt: `
           Conversation history:
@@ -77,7 +77,7 @@ export const POST = async (req: Request): Promise<Response> => {
       });
 
       const finalSlackAttempt = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: WRITE_SLACK_MESSAGE_FINAL_SYSTEM,
         prompt: `
           Conversation history:

--- a/exercises/08-agents-and-workflows/08.02-streaming-custom-data-to-the-frontend/problem/readme.md
+++ b/exercises/08-agents-and-workflows/08.02-streaming-custom-data-to-the-frontend/problem/readme.md
@@ -39,7 +39,7 @@ Next, we need to strip out the `generateText` calls inside the execute function:
 ```typescript
 // TODO - change to streamText and write to the stream as custom data parts
 const writeSlackResult = await generateText({
-  model: google('gemini-2.0-flash-001'),
+  model: google('gemini-2.5-flash'),
   system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
   prompt: `
     Conversation history:
@@ -49,7 +49,7 @@ const writeSlackResult = await generateText({
 
 // TODO - change to streamText and write to the stream as custom data parts
 const evaluateSlackResult = await generateText({
-  model: google('gemini-2.0-flash-001'),
+  model: google('gemini-2.5-flash'),
   system: EVALUATE_SLACK_MESSAGE_SYSTEM,
   prompt: `
     Conversation history:
@@ -71,7 +71,7 @@ The final Slack attempt is already streaming, which is good:
 
 ```typescript
 const finalSlackAttempt = streamText({
-  model: google('gemini-2.0-flash-001'),
+  model: google('gemini-2.5-flash'),
   system: WRITE_SLACK_MESSAGE_FINAL_SYSTEM,
   prompt: `
     Conversation history:

--- a/exercises/08-agents-and-workflows/08.02-streaming-custom-data-to-the-frontend/solution/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.02-streaming-custom-data-to-the-frontend/solution/api/chat.ts
@@ -55,7 +55,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // Write Slack message
       const writeSlackResult = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
         prompt: `
           Conversation history:
@@ -79,7 +79,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // Evaluate Slack message
       const evaluateSlackResult = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: EVALUATE_SLACK_MESSAGE_SYSTEM,
         prompt: `
           Conversation history:
@@ -106,7 +106,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // Write final Slack message
       const finalSlackAttempt = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: WRITE_SLACK_MESSAGE_FINAL_SYSTEM,
         prompt: `
           Conversation history:

--- a/exercises/08-agents-and-workflows/08.03-creating-your-own-loop/problem/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.03-creating-your-own-loop/problem/api/chat.ts
@@ -67,7 +67,7 @@ export const POST = async (req: Request): Promise<Response> => {
       // material for an example)
 
       const writeSlackResult = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
         prompt: `
           Conversation history:
@@ -91,7 +91,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // Evaluate Slack message
       const evaluateSlackResult = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: EVALUATE_SLACK_MESSAGE_SYSTEM,
         prompt: `
           Conversation history:
@@ -118,7 +118,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
       // Write final Slack message
       const finalSlackAttempt = streamText({
-        model: google('gemini-2.0-flash-001'),
+        model: google('gemini-2.5-flash'),
         system: WRITE_SLACK_MESSAGE_FINAL_SYSTEM,
         prompt: `
           Conversation history:

--- a/exercises/08-agents-and-workflows/08.03-creating-your-own-loop/solution/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.03-creating-your-own-loop/solution/api/chat.ts
@@ -55,7 +55,7 @@ export const POST = async (req: Request): Promise<Response> => {
       while (step < 2) {
         // Write Slack message
         const writeSlackResult = streamText({
-          model: google('gemini-2.0-flash-001'),
+          model: google('gemini-2.5-flash'),
           system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
           prompt: `
           Conversation history:
@@ -87,7 +87,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
         // Evaluate Slack message
         const evaluateSlackResult = streamText({
-          model: google('gemini-2.0-flash-001'),
+          model: google('gemini-2.5-flash'),
           system: EVALUATE_SLACK_MESSAGE_SYSTEM,
           prompt: `
             Conversation history:

--- a/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/problem/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/problem/api/chat.ts
@@ -55,7 +55,7 @@ export const POST = async (req: Request): Promise<Response> => {
       while (step < 2) {
         // Write Slack message
         const writeSlackResult = streamText({
-          model: google('gemini-2.0-flash-001'),
+          model: google('gemini-2.5-flash'),
           system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
           prompt: `
           Conversation history:
@@ -89,7 +89,7 @@ export const POST = async (req: Request): Promise<Response> => {
         // the feedback as a string, as well as whether we should
         // break the loop early (that the message is good enough)
         const evaluateSlackResult = streamText({
-          model: google('gemini-2.0-flash-001'),
+          model: google('gemini-2.5-flash'),
           system: EVALUATE_SLACK_MESSAGE_SYSTEM,
           prompt: `
             Conversation history:

--- a/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/problem/readme.md
+++ b/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/problem/readme.md
@@ -8,7 +8,7 @@ Our [current flow](./api/chat.ts) _always_ goes through the loop. We're going to
 while (step < 2) {
   // Write Slack message
   const writeSlackResult = streamText({
-    model: google('gemini-2.0-flash-001'),
+    model: google('gemini-2.5-flash'),
     system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
     prompt: `/* prompt content */`,
   });

--- a/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/solution/api/chat.ts
+++ b/exercises/08-agents-and-workflows/08.04-breaking-the-loop-early/solution/api/chat.ts
@@ -58,7 +58,7 @@ export const POST = async (req: Request): Promise<Response> => {
       while (step < 2) {
         // Write Slack message
         const writeSlackResult = streamText({
-          model: google('gemini-2.0-flash-001'),
+          model: google('gemini-2.5-flash'),
           system: WRITE_SLACK_MESSAGE_FIRST_DRAFT_SYSTEM,
           prompt: `
           Conversation history:
@@ -90,7 +90,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
         // Evaluate Slack message
         const evaluateSlackResult = streamObject({
-          model: google('gemini-2.0-flash-001'),
+          model: google('gemini-2.5-flash'),
           system: EVALUATE_SLACK_MESSAGE_SYSTEM,
           prompt: `
             Conversation history:

--- a/exercises/09-advanced-patterns/09.01-guardrails/problem/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.01-guardrails/problem/api/chat.ts
@@ -42,7 +42,7 @@ export const POST = async (req: Request): Promise<Response> => {
       }
 
       const streamTextResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 

--- a/exercises/09-advanced-patterns/09.01-guardrails/solution/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.01-guardrails/solution/api/chat.ts
@@ -22,7 +22,7 @@ export const POST = async (req: Request): Promise<Response> => {
     execute: async ({ writer }) => {
       console.time('Guardrail Time');
       const guardrailResult = await generateText({
-        model: google('gemini-2.0-flash-lite'),
+        model: google('gemini-2.5-flash-lite'),
         system: GUARDRAIL_SYSTEM,
         messages: modelMessages,
       });
@@ -57,7 +57,7 @@ export const POST = async (req: Request): Promise<Response> => {
       }
 
       const streamTextResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 

--- a/exercises/09-advanced-patterns/09.02-model-router/problem/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.02-model-router/problem/api/chat.ts
@@ -9,8 +9,8 @@ import {
   type UIMessage,
 } from 'ai';
 
-const ADVANCED_MODEL = google('gemini-2.0-flash');
-const BASIC_MODEL = google('gemini-2.0-flash-lite');
+const ADVANCED_MODEL = google('gemini-2.5-flash');
+const BASIC_MODEL = google('gemini-2.5-flash-lite');
 
 export type MyMessage = UIMessage<{
   model: 'advanced' | 'basic';

--- a/exercises/09-advanced-patterns/09.02-model-router/solution/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.02-model-router/solution/api/chat.ts
@@ -9,8 +9,8 @@ import {
   type UIMessage,
 } from 'ai';
 
-const ADVANCED_MODEL = google('gemini-2.0-flash');
-const BASIC_MODEL = google('gemini-2.0-flash-lite');
+const ADVANCED_MODEL = google('gemini-2.5-flash');
+const BASIC_MODEL = google('gemini-2.5-flash-lite');
 
 export type MyMessage = UIMessage<{
   model: 'advanced' | 'basic';

--- a/exercises/09-advanced-patterns/09.03-comparing-multiple-outputs/problem/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.03-comparing-multiple-outputs/problem/api/chat.ts
@@ -43,12 +43,12 @@ export const POST = async (req: Request): Promise<Response> => {
   const stream = createUIMessageStream<MyMessage>({
     execute: async ({ writer }) => {
       const firstStreamResult = streamText({
-        model: google('gemini-2.0-flash-lite'),
+        model: google('gemini-2.5-flash-lite'),
         messages: modelMessages,
       });
 
       const secondStreamResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 

--- a/exercises/09-advanced-patterns/09.03-comparing-multiple-outputs/problem/readme.md
+++ b/exercises/09-advanced-patterns/09.03-comparing-multiple-outputs/problem/readme.md
@@ -10,12 +10,12 @@ The basic setup uses a `createUIMessageStream` again, with two `streamText` call
 const stream = createUIMessageStream<MyMessage>({
   execute: async ({ writer }) => {
     const firstStreamResult = streamText({
-      model: google('gemini-2.0-flash-lite'),
+      model: google('gemini-2.5-flash-lite'),
       messages: modelMessages,
     });
 
     const secondStreamResult = streamText({
-      model: google('gemini-2.0-flash'),
+      model: google('gemini-2.5-flash'),
       messages: modelMessages,
     });
 
@@ -26,7 +26,7 @@ const stream = createUIMessageStream<MyMessage>({
 });
 ```
 
-Both stream calls are being passed exactly the same messages, but we're using two different models - one using `gemini-2.0-flash-lite` and the other using `gemini-2.0-flash`.
+Both stream calls are being passed exactly the same messages, but we're using two different models - one using `gemini-2.5-flash-lite` and the other using `gemini-2.5-flash`.
 
 Just below this, we need to use `Promise.all` to call `streamModelText` for each model and pass in the appropriate model.
 

--- a/exercises/09-advanced-patterns/09.03-comparing-multiple-outputs/solution/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.03-comparing-multiple-outputs/solution/api/chat.ts
@@ -56,24 +56,24 @@ export const POST = async (req: Request): Promise<Response> => {
   const stream = createUIMessageStream<MyMessage>({
     execute: async ({ writer }) => {
       const firstStreamResult = streamText({
-        model: google('gemini-2.0-flash-lite'),
+        model: google('gemini-2.5-flash-lite'),
         messages: modelMessages,
       });
 
       const secondStreamResult = streamText({
-        model: google('gemini-2.0-flash'),
+        model: google('gemini-2.5-flash'),
         messages: modelMessages,
       });
 
       await Promise.all([
         streamModelText({
           textStream: firstStreamResult.textStream,
-          model: 'Gemini 2.0 Flash Lite',
+          model: 'Gemini 2.5 Flash Lite',
           writer,
         }),
         streamModelText({
           textStream: secondStreamResult.textStream,
-          model: 'Gemini 2.0 Flash',
+          model: 'Gemini 2.5 Flash',
           writer,
         }),
       ]);

--- a/exercises/09-advanced-patterns/09.04-research-workflow/solution/api/chat.ts
+++ b/exercises/09-advanced-patterns/09.04-research-workflow/solution/api/chat.ts
@@ -24,7 +24,7 @@ const generateQueriesForTavily = (
   modelMessages: ModelMessage[],
 ) => {
   const queriesResult = streamObject({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     system: `
       You are a helpful assistant that generates queries to search the web for information.
 
@@ -127,7 +127,7 @@ const streamFinalSummary = async (
     .join('\n');
 
   const answerResult = streamText({
-    model: google('gemini-2.0-flash'),
+    model: google('gemini-2.5-flash'),
     system: `You are a helpful assistant that answers questions based on the search results.
       <rules>
       You should use the search results to answer the question.

--- a/exercises/99-reference/99.02-defining-tools/explainer/main.ts
+++ b/exercises/99-reference/99.02-defining-tools/explainer/main.ts
@@ -4,7 +4,7 @@ import { styleText } from 'node:util';
 import z from 'zod';
 
 const result = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Log the message "Hello, world!" to the console',
   tools: {
     logToConsole: tool({

--- a/exercises/99-reference/99.02-defining-tools/explainer/readme.md
+++ b/exercises/99-reference/99.02-defining-tools/explainer/readme.md
@@ -4,7 +4,7 @@ We're inside a `streamText` call here where we have a prompt saying, log the mes
 
 ```ts
 const result = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Log the message "Hello, world!" to the console',
   tools: {
     // ...explained below

--- a/exercises/99-reference/99.03-consume-stream/explainer.1/main.ts
+++ b/exercises/99-reference/99.03-consume-stream/explainer.1/main.ts
@@ -4,7 +4,7 @@ import { streamText } from 'ai';
 console.log('Process starting...');
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
   onFinish: () => {
     console.log('Stream finished!');

--- a/exercises/99-reference/99.03-consume-stream/explainer.1/readme.md
+++ b/exercises/99-reference/99.03-consume-stream/explainer.1/readme.md
@@ -2,7 +2,7 @@ The AI SDK, by default, does not always wait for a stream to be completed. This 
 
 ## The Problem
 
-In this code here, we're calling `streamText`, passing "Hello, world!" to Gemini 2.0 Flash, and we have an `onFinish` on the `streamTextResult`.
+In this code here, we're calling `streamText`, passing "Hello, world!" to Gemini 2.5 Flash, and we have an `onFinish` on the `streamTextResult`.
 
 ```ts
 import { google } from '@ai-sdk/google';
@@ -11,7 +11,7 @@ import { streamText } from 'ai';
 console.log('Process starting...');
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
   onFinish: () => {
     console.log('Stream finished!');
@@ -51,7 +51,7 @@ import { streamText } from 'ai';
 console.log('Process starting...');
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
   onFinish: () => {
     console.log('Stream finished!');
@@ -88,7 +88,7 @@ import { streamText } from 'ai';
 console.log('Process starting...');
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
   onFinish: () => {
     console.log('Stream finished!');
@@ -124,7 +124,7 @@ import { consumeStream, streamText } from 'ai';
 console.log('Process starting...');
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
   onFinish: () => {
     console.log('Stream finished!');

--- a/exercises/99-reference/99.03-consume-stream/explainer.2/main.ts
+++ b/exercises/99-reference/99.03-consume-stream/explainer.2/main.ts
@@ -4,7 +4,7 @@ import { consumeStream, streamText } from 'ai';
 console.log('Process starting...');
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
   onFinish: () => {
     console.log('Stream finished!');

--- a/exercises/99-reference/99.07-message-metadata/explainer/main.ts
+++ b/exercises/99-reference/99.07-message-metadata/explainer/main.ts
@@ -9,7 +9,7 @@ type MyMetadata = {
 type MyMessage = UIMessage<MyMetadata>;
 
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
 });
 

--- a/exercises/99-reference/99.07-message-metadata/explainer/readme.md
+++ b/exercises/99-reference/99.07-message-metadata/explainer/readme.md
@@ -19,7 +19,7 @@ We then have a standard `streamText` result here:
 
 ```ts
 const streamTextResult = streamText({
-  model: google('gemini-2.0-flash'),
+  model: google('gemini-2.5-flash'),
   prompt: 'Hello, world!',
 });
 ```

--- a/exercises/99-reference/99.09-start-and-finish-parts/explainer/api/chat.ts
+++ b/exercises/99-reference/99.09-start-and-finish-parts/explainer/api/chat.ts
@@ -47,7 +47,7 @@ export const POST = async (req: Request): Promise<Response> => {
       writeTextPart(writer, 'Paragraph 1: ');
 
       const firstParagraphResult = streamText({
-        model: google('gemini-2.0-flash-lite'),
+        model: google('gemini-2.5-flash-lite'),
         messages: [
           ...modelMessages,
           {
@@ -71,7 +71,7 @@ export const POST = async (req: Request): Promise<Response> => {
       writeTextPart(writer, 'Paragraph 2: ');
 
       const secondParagraphResult = streamText({
-        model: google('gemini-2.0-flash-lite'),
+        model: google('gemini-2.5-flash-lite'),
         messages: [
           ...modelMessages,
           {
@@ -96,7 +96,7 @@ export const POST = async (req: Request): Promise<Response> => {
       writeTextPart(writer, 'Paragraph 3: ');
 
       const thirdParagraphResult = streamText({
-        model: google('gemini-2.0-flash-lite'),
+        model: google('gemini-2.5-flash-lite'),
         messages: [
           ...modelMessages,
           {

--- a/exercises/99-reference/99.09-start-and-finish-parts/explainer/readme.md
+++ b/exercises/99-reference/99.09-start-and-finish-parts/explainer/readme.md
@@ -46,7 +46,7 @@ We do this three times until we have three paragraphs. Here's the code for the f
 writeTextPart(writer, 'Paragraph 1: ');
 
 const firstParagraphResult = streamText({
-  model: google('gemini-2.0-flash-lite'),
+  model: google('gemini-2.5-flash-lite'),
   messages: [
     ...modelMessages,
     {


### PR DESCRIPTION
Replaces model references to gemini-2.0-flash* in favour of gemini-2.5-flash ones because they are deprecated, and cause 429 response errors, based on the following document: https://ai.google.dev/gemini-api/docs/deprecations